### PR TITLE
feat(auto): add full auto paths

### DIFF
--- a/deploy/pathplanner/autos/Left Coral.auto
+++ b/deploy/pathplanner/autos/Left Coral.auto
@@ -5,21 +5,85 @@
     "data": {
       "commands": [
         {
-          "type": "path",
+          "type": "parallel",
           "data": {
-            "pathName": "Left Cower"
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "Left Coral"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
           }
         },
         {
-          "type": "named",
+          "type": "sequential",
           "data": {
-            "name": "Shoot Coral"
+            "commands": [
+              {
+                "type": "named",
+                "data": {
+                  "name": "Correct Elevator"
+                }
+              },
+              {
+                "type": "race",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Shoot Coral"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Hold Elevator"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
       ]
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "Left",
   "choreoAuto": false
 }

--- a/deploy/pathplanner/autos/Left Cower.auto
+++ b/deploy/pathplanner/autos/Left Cower.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "Left",
   "choreoAuto": false
 }

--- a/deploy/pathplanner/autos/Left Full Coral.auto
+++ b/deploy/pathplanner/autos/Left Full Coral.auto
@@ -1,0 +1,376 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Left Coral"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Left Coral Intake"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake Coral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Left Coral Return"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Left Coral Intake 2"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake Coral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Left Coral Return 2"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": "Left",
+  "choreoAuto": false
+}

--- a/deploy/pathplanner/autos/Middle Coral.auto
+++ b/deploy/pathplanner/autos/Middle Coral.auto
@@ -20,6 +20,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "Middle",
   "choreoAuto": false
 }

--- a/deploy/pathplanner/autos/Right Coral.auto
+++ b/deploy/pathplanner/autos/Right Coral.auto
@@ -5,21 +5,85 @@
     "data": {
       "commands": [
         {
-          "type": "path",
+          "type": "parallel",
           "data": {
-            "pathName": "Right Cower"
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "Right Coral"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Raise Elevator"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
           }
         },
         {
-          "type": "named",
+          "type": "sequential",
           "data": {
-            "name": "Shoot Coral"
+            "commands": [
+              {
+                "type": "named",
+                "data": {
+                  "name": "Correct Elevator"
+                }
+              },
+              {
+                "type": "race",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Shoot Coral"
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Hold Elevator"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
       ]
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "Right",
   "choreoAuto": false
 }

--- a/deploy/pathplanner/autos/Right Cower.auto
+++ b/deploy/pathplanner/autos/Right Cower.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "Right",
   "choreoAuto": false
 }

--- a/deploy/pathplanner/autos/Right Full Coral.auto
+++ b/deploy/pathplanner/autos/Right Full Coral.auto
@@ -1,0 +1,376 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Right Coral"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Right Coral Intake"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake Coral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Right Coral Return"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Right Coral Intake 2"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Lower Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake Coral"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "parallel",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "path",
+                      "data": {
+                        "pathName": "Right Coral Return 2"
+                      }
+                    },
+                    {
+                      "type": "sequential",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Raise Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "Correct Elevator"
+                      }
+                    },
+                    {
+                      "type": "race",
+                      "data": {
+                        "commands": [
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Shoot Coral"
+                            }
+                          },
+                          {
+                            "type": "named",
+                            "data": {
+                              "name": "Hold Elevator"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": "Right",
+  "choreoAuto": false
+}

--- a/deploy/pathplanner/paths/Left Coral Intake 2.path
+++ b/deploy/pathplanner/paths/Left Coral Intake 2.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 3.9148967545120796,
+        "y": 5.344634930645977
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.0167801895771866,
+        "y": 6.0615161023849335
+      },
+      "isLocked": false,
+      "linkedName": "Left Coral Return"
+    },
+    {
+      "anchor": {
+        "x": 1.628047321460864,
+        "y": 7.1622181221290875
+      },
+      "prevControl": {
+        "x": 2.940095524030397,
+        "y": 6.14311445370697
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Left Coral Intake"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -55.0
+  },
+  "reversed": false,
+  "folder": "Left",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": -59.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Left Coral Intake.path
+++ b/deploy/pathplanner/paths/Left Coral Intake.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.19888698630137,
+        "y": 5.1970034246575345
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 4.137359420073654,
+        "y": 5.815846857971281
+      },
+      "isLocked": false,
+      "linkedName": "Left First Coral"
+    },
+    {
+      "anchor": {
+        "x": 1.628047321460864,
+        "y": 7.1622181221290875
+      },
+      "prevControl": {
+        "x": 3.4347070004332823,
+        "y": 6.178202363280551
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Left Coral Intake"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -55.0
+  },
+  "reversed": false,
+  "folder": "Left",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": -119.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Left Coral Return 2.path
+++ b/deploy/pathplanner/paths/Left Coral Return 2.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.628047321460864,
+        "y": 7.1622181221290875
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.1966274222693025,
+        "y": 6.612941321087837
+      },
+      "isLocked": false,
+      "linkedName": "Left Coral Intake"
+    },
+    {
+      "anchor": {
+        "x": 3.6878488390069255,
+        "y": 5.229695827082583
+      },
+      "prevControl": {
+        "x": 3.2822406523286003,
+        "y": 5.6000860484299215
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Left",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": -55.0
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Left Coral Return.path
+++ b/deploy/pathplanner/paths/Left Coral Return.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.628047321460864,
+        "y": 7.1622181221290875
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.6280473214608637,
+        "y": 7.1622181221290875
+      },
+      "isLocked": false,
+      "linkedName": "Left Coral Intake"
+    },
+    {
+      "anchor": {
+        "x": 3.9148967545120796,
+        "y": 5.344634930645977
+      },
+      "prevControl": {
+        "x": 2.9148967545120796,
+        "y": 5.344634930645977
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Left Coral Return"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": -59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Left",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": -55.0
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Left Coral.path
+++ b/deploy/pathplanner/paths/Left Coral.path
@@ -8,8 +8,8 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 6.338146106881937,
-        "y": 5.929869682423468
+        "x": 6.399681391827616,
+        "y": 5.938493139623239
       },
       "isLocked": false,
       "linkedName": "Left Start Point"
@@ -20,12 +20,12 @@
         "y": 5.1970034246575345
       },
       "prevControl": {
-        "x": 6.173123799219414,
-        "y": 5.682362244109326
+        "x": 6.146438957302815,
+        "y": 5.685472760679671
       },
       "nextControl": null,
       "isLocked": false,
-      "linkedName": null
+      "linkedName": "Left First Coral"
     }
   ],
   "rotationTargets": [],
@@ -33,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -42,10 +42,10 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -120.96375653207339
+    "rotation": -119.99999999999999
   },
   "reversed": false,
-  "folder": null,
+  "folder": "Left",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/deploy/pathplanner/paths/Left Cower.path
+++ b/deploy/pathplanner/paths/Left Cower.path
@@ -33,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -45,7 +45,7 @@
     "rotation": 180.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "Left",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/deploy/pathplanner/paths/Middle Coral.path
+++ b/deploy/pathplanner/paths/Middle Coral.path
@@ -33,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -45,7 +45,7 @@
     "rotation": 180.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "Middle",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/deploy/pathplanner/paths/Right Coral Intake 2.path
+++ b/deploy/pathplanner/paths/Right Coral Intake 2.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 3.9028199711552367,
+        "y": 2.6925876815230754
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.3527598476830267,
+        "y": 0.8850047136245873
+      },
+      "isLocked": false,
+      "linkedName": "Right Coral Return"
+    },
+    {
+      "anchor": {
+        "x": 2.040285723650896,
+        "y": 0.48994453712745895
+      },
+      "prevControl": {
+        "x": 2.9853712330750106,
+        "y": 1.5893169195586212
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Right Intake"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 55.0
+  },
+  "reversed": false,
+  "folder": "Right",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Right Coral Intake.path
+++ b/deploy/pathplanner/paths/Right Coral Intake.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.303001669424551,
+        "y": 2.897452618634259
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 4.702651214036265,
+        "y": 2.3865146833432958
+      },
+      "isLocked": false,
+      "linkedName": "Right First Coral"
+    },
+    {
+      "anchor": {
+        "x": 2.040285723650896,
+        "y": 0.48994453712745895
+      },
+      "prevControl": {
+        "x": 3.2503955899124795,
+        "y": 1.3713132259947345
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Right Intake"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 55.0
+  },
+  "reversed": false,
+  "folder": "Right",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 119.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Right Coral Return 2.path
+++ b/deploy/pathplanner/paths/Right Coral Return 2.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 2.040285723650896,
+        "y": 0.48994453712745895
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.137400475299372,
+        "y": 2.0834107223473413
+      },
+      "isLocked": false,
+      "linkedName": "Right Intake"
+    },
+    {
+      "anchor": {
+        "x": 3.6527059936523427,
+        "y": 2.856906726978443
+      },
+      "prevControl": {
+        "x": 2.9209930874779606,
+        "y": 1.7757704455791474
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Right",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 55.0
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Right Coral Return.path
+++ b/deploy/pathplanner/paths/Right Coral Return.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 2.040285723650896,
+        "y": 0.48994453712745895
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.9252411760717543,
+        "y": 1.507351096633226
+      },
+      "isLocked": false,
+      "linkedName": "Right Intake"
+    },
+    {
+      "anchor": {
+        "x": 3.9028199711552367,
+        "y": 2.6925876815230754
+      },
+      "prevControl": {
+        "x": 3.240251902555742,
+        "y": 1.893966770892869
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "Right Coral Return"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Right",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 55.0
+  },
+  "useDefaultConstraints": true
+}

--- a/deploy/pathplanner/paths/Right Coral.path
+++ b/deploy/pathplanner/paths/Right Coral.path
@@ -8,24 +8,24 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 6.760725126827771,
-        "y": 2.0662702011985377
+        "x": 6.85973827734249,
+        "y": 2.04156613222464
       },
       "isLocked": false,
       "linkedName": "Right Start Point"
     },
     {
       "anchor": {
-        "x": 5.168835616438356,
-        "y": 2.868022260273973
+        "x": 5.303001669424551,
+        "y": 2.897452618634259
       },
       "prevControl": {
-        "x": 5.480040617566821,
-        "y": 2.7379633297556674
+        "x": 5.5292220326691774,
+        "y": 2.7903459932714196
       },
       "nextControl": null,
       "isLocked": false,
-      "linkedName": null
+      "linkedName": "Right First Coral"
     }
   ],
   "rotationTargets": [],
@@ -33,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -42,10 +42,10 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": 121.42956561483854
+    "rotation": 119.99999999999999
   },
   "reversed": false,
-  "folder": null,
+  "folder": "Right",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/deploy/pathplanner/paths/Right Cower.path
+++ b/deploy/pathplanner/paths/Right Cower.path
@@ -33,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 4.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -45,7 +45,7 @@
     "rotation": 180.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "Right",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 180.0

--- a/deploy/pathplanner/settings.json
+++ b/deploy/pathplanner/settings.json
@@ -2,10 +2,18 @@
   "robotWidth": 0.7747,
   "robotLength": 0.9144,
   "holonomicMode": true,
-  "pathFolders": [],
-  "autoFolders": [],
-  "defaultMaxVel": 3.0,
-  "defaultMaxAccel": 3.0,
+  "pathFolders": [
+    "Left",
+    "Middle",
+    "Right"
+  ],
+  "autoFolders": [
+    "Left",
+    "Middle",
+    "Right"
+  ],
+  "defaultMaxVel": 4.0,
+  "defaultMaxAccel": 4.0,
   "defaultMaxAngVel": 540.0,
   "defaultMaxAngAccel": 720.0,
   "defaultNominalVoltage": 12.0,

--- a/src/main/kotlin/org/frc5183/Robot.kt
+++ b/src/main/kotlin/org/frc5183/Robot.kt
@@ -2,7 +2,6 @@ package org.frc5183
 
 import com.pathplanner.lib.auto.AutoBuilder
 import com.pathplanner.lib.auto.NamedCommands
-import com.pathplanner.lib.pathfinding.Pathfinding
 import com.revrobotics.ColorSensorV3
 import com.revrobotics.spark.SparkMax
 import edu.wpi.first.hal.FRCNetComm.tInstances
@@ -16,11 +15,14 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj.util.WPILibVersion
 import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.CommandScheduler
+import edu.wpi.first.wpilibj2.command.InstantCommand
+import org.frc5183.commands.coral.IntakeCoralCommand
 import org.frc5183.commands.coral.ShootCoralCommand
+import org.frc5183.commands.elevator.CorrectElevatorCommand
+import org.frc5183.commands.elevator.HoldElevatorCommand
 import org.frc5183.commands.elevator.LowerElevatorCommand
 import org.frc5183.commands.elevator.RaiseElevatorCommand
 import org.frc5183.constants.*
-import org.frc5183.math.auto.pathfinding.DummyPathfinder
 import org.frc5183.subsystems.climber.ClimberSubsystem
 import org.frc5183.subsystems.climber.io.RealClimberIO
 import org.frc5183.subsystems.coral.CoralSubsystem
@@ -108,7 +110,6 @@ object Robot : LoggedRobot() {
 
         // Set the pathfinder to use the LocalADStarAK pathfinder so that
         //  we can use the AdvantageKit replay logging.
-        Pathfinding.setPathfinder(DummyPathfinder("Example Path.path"))
 
         vision =
             VisionSubsystem(
@@ -161,13 +162,29 @@ object Robot : LoggedRobot() {
             coralSubsystem,
         )
 
-        NamedCommands.registerCommands(
-            mapOf(
-                "Shoot Coral" to ShootCoralCommand(coralSubsystem),
-                "Raise Elevator" to RaiseElevatorCommand(elevator),
-                "Lower Elevator" to LowerElevatorCommand(elevator),
-            ),
-        )
+        if (State.mode == State.Mode.REAL) {
+            NamedCommands.registerCommands(
+                mapOf(
+                    "Shoot Coral" to ShootCoralCommand(coralSubsystem),
+                    "Intake Coral" to IntakeCoralCommand(coralSubsystem),
+                    "Raise Elevator" to RaiseElevatorCommand(elevator),
+                    "Lower Elevator" to LowerElevatorCommand(elevator),
+                    "Correct Elevator" to CorrectElevatorCommand(elevator),
+                    "Hold Elevator" to HoldElevatorCommand(elevator),
+                ),
+            )
+        } else {
+            NamedCommands.registerCommands(
+                mapOf(
+                    "Shoot Coral" to InstantCommand({ println("Shoot Coral") }),
+                    "Intake Coral" to InstantCommand({ println("Intake Coral") }),
+                    "Raise Elevator" to InstantCommand({ println("Raise Elevator") }),
+                    "Lower Elevator" to InstantCommand({ println("Lower Elevator") }),
+                    "Correct Elevator" to InstantCommand({ println("Correct Elevator") }),
+                    "Hold Elevator" to InstantCommand({ println("Hold Elevator") }),
+                ),
+            )
+        }
 
         autoChooser = AutoBuilder.buildAutoChooser()
         SmartDashboard.putData("Auto choices", autoChooser)


### PR DESCRIPTION
Auto paths to score 2-3 L4 coral. 

Notes:
- Maximum speed measurements have not been done, so speeds are guesses and therefore estimated driving times are even more estimated.
- Apart from driving, no subsystems have been tested.
- Vision will likely be needed for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Autonomous routines now support parallel and sequential command flows for more intricate behaviors.
  - New paths and configurations have been introduced for various autonomous routines, enhancing navigation capabilities.
  - The robot registers an expanded set of commands in Real mode while providing simulated feedback for testing.
  - New configuration files for "Left Full Coral," "Right Full Coral," and various intake and return paths have been added.

- **Chores**
  - Configuration settings have been updated with increased velocity and acceleration limits.
  - Organizational improvements now categorize autonomous routines with clear designations and optimized waypoint controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->