### PR TITLE
fix(math/curve): add missing parenthesis in logistic curve

### DIFF
--- a/src/main/kotlin/org/frc5183/constants/Controls.kt
+++ b/src/main/kotlin/org/frc5183/constants/Controls.kt
@@ -49,7 +49,7 @@ object Controls {
     /**
      * The curve applied to the translation inputs, among other input filtering (deadband, range clamps, etc.)
      */
-    val TRANSLATION_CURVE = LogisticCurve(25.0, 0.6)
+    val TRANSLATION_CURVE = LogisticCurve(8.5, 0.6)
 
     /**
      * The curve applied to the rotation input, among other input filtering (deadband, range clamps, etc.)

--- a/src/main/kotlin/org/frc5183/math/curve/LogisticCurve.kt
+++ b/src/main/kotlin/org/frc5183/math/curve/LogisticCurve.kt
@@ -29,6 +29,6 @@ class LogisticCurve(
             0.0 -> 0.0
             1.0 -> 1.0
             -1.0 -> -1.0
-            else -> input.sign * (1 / (1 + E.pow(-a * abs(input) - b)))
+            else -> input.sign * (1 / (1 + E.pow(-a * (abs(input) - b))))
         }
 }

--- a/src/test/kotlin/org/frc5183/math/curve/LogisticCurveTest.kt
+++ b/src/test/kotlin/org/frc5183/math/curve/LogisticCurveTest.kt
@@ -25,7 +25,7 @@ class LogisticCurveTest {
             0.0 -> 0.0
             -1.0 -> -1.0
             1.0 -> 1.0
-            else -> input.sign * (1 / (1 + E.pow(-a * abs(input) - b)))
+            else -> input.sign * (1 / (1 + E.pow(-a * (abs(input) - b))))
         }
 
     @Test


### PR DESCRIPTION
also make the translation curve a bit nicer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Fine-tuned the translation input behavior by updating the `TRANSLATION_CURVE` constant for improved control responsiveness.
	- Optimized the underlying calculations in the logistic curve processing to enhance overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->